### PR TITLE
make all events emitted from Persistence to have the same structure

### DIFF
--- a/lib/Persistence.js
+++ b/lib/Persistence.js
@@ -47,7 +47,7 @@ class Persistence extends EventEmitter {
         if(!options.dispatcher) options.dispatcher = this;
 
         this.config = options;
-        
+
         extend(this, options);
 
         var ormConfig = options.orm;
@@ -200,20 +200,23 @@ class Persistence extends EventEmitter {
      */
     emitModelEvent(identity, action, record){
 
-        //ie: persistence.user.update
-        var etype = this.getEventType(identity, action);
-        this.dispatcher.emit(etype, record);
-
-        //ie: persistence.user.*
-        etype = this.getEventType(identity, '*');
-        this.dispatcher.emit(etype, record);
-
-        //catch all event
-        this.dispatcher.emit('persistence.*', {
+        let event = {
             identity,
             action,
             record
-        });
+        };
+
+        //ie: persistence.user.update
+        event.type = this.getEventType(identity, action);
+        this.dispatcher.emit(event.type, event);
+
+        //ie: persistence.user.*
+        event.type = this.getEventType(identity, '*');
+        this.dispatcher.emit(event.type, event);
+
+        //catch all event
+        event.type = 'persistence.*';
+        this.dispatcher.emit(event.type, event);
     }
 
     /*


### PR DESCRIPTION
Closes #1, all events emitted from `emitModelEvent` now have the same structure:

```js
let event = {
    identity,
    action,
    record
};
event.type = 'persistence.<entity>.<action>';
```
