### PR TITLE
Update REGEXP_FILE to match only JS files

### DIFF
--- a/lib/Persistence.js
+++ b/lib/Persistence.js
@@ -21,7 +21,7 @@ var DEFAULTS = {
     eventTypePrefix: 'persistence',
     timeout: 0.5 * 60 * 1000,// 30s timeout,
     modelsDir: process.cwd() + '/models',
-    REGEXP_FILE: /[^\/\~]$/,
+    REGEXP_FILE: /^.*\.(js)$/,
     orm: require('./config')
 };
 


### PR DESCRIPTION
This PR fixed #9 by updating the **REGEXP_FILE** to be `/^.*\.(js)$/` and match only JS files.