### PR TITLE
Remove attributes that are null or undefined

### DIFF
--- a/lib/BaseModel.js
+++ b/lib/BaseModel.js
@@ -51,6 +51,7 @@ var BaseModel = Waterline.Collection.extend({
         next();
     },
     updateOrCreate: function(criteria, values, populate, cb) {
+        
         if(typeof populate === 'function') {
             cb = populate;
             populate = undefined;
@@ -122,6 +123,13 @@ BaseModel.extend = function(protoProps, staticProps) {
     });
 
     protoProps.attributes = extend({}, this.prototype.attributes, protoProps.attributes);
+
+    Object.keys(protoProps.attributes).forEach((key)=>{
+        if(protoProps.attributes[key] == null) {
+            delete protoProps.attributes[key];
+        }
+    });
+
     return Waterline.Collection.extend.call(this, protoProps, staticProps);
 };
 


### PR DESCRIPTION
This closes #17, we remove all attributes that are either null or undefined. To unset a field:

```js
BaseModel.extend({
  attributes: {
    uuid: undefined
  }
});
```